### PR TITLE
Enrich API info.description with plain English marketplace summary

### DIFF
--- a/src/main/resources/openapi/openapi-spec.yml
+++ b/src/main/resources/openapi/openapi-spec.yml
@@ -1,7 +1,15 @@
 openapi: 3.0.0
 info:
   title: Common Platform API Case URN Mapper
-  description: Case URL Mapper specification
+  description: |
+    Looks up a court case using its case reference number and returns what other
+    court services need to find and display that case.
+
+    Case reference numbers appear on all court documents and correspondence — they
+    are the numbers that case workers, prosecutors, and legal professionals use to
+    refer to a case. This API takes that reference number and returns the details
+    needed to access the same case in other court services. A refresh option is
+    available to ensure the most up-to-date information is returned.
   version: 0.1.0
   contact:
     email: no-reply@hmcts.com


### PR DESCRIPTION
## What changed
- Replaced the single-line `info.description` in `openapi-spec.yml` with a multi-paragraph plain English explanation of what the API does, who uses it, and what the optional refresh flag is for

## Why it's needed
The AMP catalog front door surfaces `info.description` as the first thing a consumer sees when browsing the marketplace. The previous one-liner ("Case URL Mapper specification") gave no useful context to someone unfamiliar with the domain. The new description explains the URN-to-ID mapping in business terms so API consumers can understand the purpose without reading the full spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)